### PR TITLE
feat: use terraform-docs v0.22.0

### DIFF
--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -26,33 +26,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-darwin-amd64.tar.gz",
-      "checksum": "DDF4B53925D857AE81210EBEDA32B429A17385D6E4561AB1972067A9CCB36873",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-darwin-amd64.tar.gz",
+      "checksum": "797ED9AFAAAFDE69F33F8CFA00602E7C57249C63C58B014122A69726584EB8EF",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-darwin-arm64.tar.gz",
-      "checksum": "92D6988D8C59C25AA1724068F4BC2D0F01A9D4706077E258E946E944AD7EEE03",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-darwin-arm64.tar.gz",
+      "checksum": "A8A698C8C1BD0A77189FD15A6F9AC9D99445B1E22F5376A8F7C830FA7407592D",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-linux-amd64.tar.gz",
-      "checksum": "2FDD81B8D21FF1498CD559AF0DCC5D155835F84600DB06D3923E217124FC735A",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-linux-amd64.tar.gz",
+      "checksum": "8EC66616777C66F3E622AF4F2853E8AE399F38908AD4B262C9C526DD42501369",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-linux-arm64.tar.gz",
-      "checksum": "35B2E6846268841484E6EEA7D00D7DFE2C94B4725E52CFE19AA6C26A86C32EDC",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-linux-arm64.tar.gz",
+      "checksum": "4FECCD471E0595546271BDE7AABD275A5C1A5B055D6CD89C2678B38CED1376F6",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-windows-amd64.zip",
-      "checksum": "9F45957D50656EC91C6172D73A6C9E6A22DF2CCC7CA880CF288D19D6F5E349DB",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-windows-amd64.zip",
+      "checksum": "23F6539F10EF5C34F73A7CCFEB7474EA82BC3E591E46E59C994B10F54BE83025",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.21.0/terraform-docs-v0.21.0-windows-arm64.zip",
-      "checksum": "A9CA3577209B2C5F21A0D89AFDEE82E6AD912058D64C364B7A7535ABB57E3092",
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.22.0/terraform-docs-v0.22.0-windows-arm64.zip",
+      "checksum": "952C3A3B28BEBB18BF7FDA8F130B4A64F567693F73E78301791BC89739560716",
       "algorithm": "sha256"
     },
     {
@@ -81,8 +81,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.492.0/registry.yaml",
-      "checksum": "7BD018BBFC66C2B6E69607418D806F21B8B0E8554A2C02709A547F756D2B7CE1",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.495.0/registry.yaml",
+      "checksum": "57C651A422B0F56D57B4D39555EBFAD99B20E54D7F9C4241EDB2138C9990CCC1",
       "algorithm": "sha256"
     }
   ]

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,8 +9,8 @@ checksum:
     - all
 registries:
   - type: standard
-    ref: v4.492.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.495.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: terraform-docs/terraform-docs@v0.21.0
+  - name: terraform-docs/terraform-docs@v0.22.0
   - name: terraform-linters/tflint@v0.61.0
   - name: aquasecurity/trivy@v0.69.3

--- a/terraform/pagerduty/sample01/README.md
+++ b/terraform/pagerduty/sample01/README.md
@@ -8,32 +8,32 @@ PagerDuty を Terraform で管理するための動作確認をおこなう。
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 3 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 3 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [pagerduty_user.u](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/data-sources/user) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_email"></a> [email](#input\_email) | Your PagerDuty e-mail address. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_your_account"></a> [your\_account](#output\_your\_account) | Your PagerDuty Account information. |
 | <a name="output_your_id"></a> [your\_id](#output\_your\_id) | Your PagerDuty Account ID. |
 

--- a/terraform/pagerduty/sample02/README.md
+++ b/terraform/pagerduty/sample02/README.md
@@ -10,7 +10,7 @@ apply して output をファイルに出力することで、環境を選ばず
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 3 |
 | <a name="requirement_template"></a> [template](#requirement\_template) | >= 2 |
@@ -18,14 +18,14 @@ apply して output をファイルに出力することで、環境を選ばず
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 3 |
 | <a name="provider_template"></a> [template](#provider\_template) | >= 2 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [pagerduty_users.all](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/data-sources/users) | data source |
 | [template_file.import_pagerduty_user](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 | [template_file.resource_pagerduty_user](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
@@ -33,7 +33,7 @@ apply して output をファイルに出力することで、環境を選ばず
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_import_pagerduty_user"></a> [import\_pagerduty\_user](#output\_import\_pagerduty\_user) | terraform output -raw import\_pagerduty\_user > ../users/users\_import.tf |
 | <a name="output_resource_pagerduty_user"></a> [resource\_pagerduty\_user](#output\_resource\_pagerduty\_user) | terraform output -raw resource\_pagerduty\_user > ../users/users.tf |
 

--- a/terraform_pdfbv2/pagerduty/01_service_custom_field/01_definition/README.md
+++ b/terraform_pdfbv2/pagerduty/01_service_custom_field/01_definition/README.md
@@ -11,27 +11,27 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 3.25.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 3.25.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [pagerduty_service_custom_field.simple_string](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_custom_field) | resource |
 | [pagerduty_service_custom_field.single_value_fixed](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_custom_field) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_single_value_fixed_values"></a> [single\_value\_fixed\_values](#input\_single\_value\_fixed\_values) | 固定値の単一選択フィールドの選択可能な値 | `list(string)` | <pre>[<br/>  "production",<br/>  "staging",<br/>  "development"<br/>]</pre> | no |
 
 <!-- END_TF_DOCS -->

--- a/terraform_pdfbv2/pagerduty/01_service_custom_field/02_set_value/README.md
+++ b/terraform_pdfbv2/pagerduty/01_service_custom_field/02_set_value/README.md
@@ -10,20 +10,20 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 3.25.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 3.25.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [pagerduty_escalation_policy.this](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/escalation_policy) | resource |
 | [pagerduty_service.this](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
 | [pagerduty_service_custom_field_value.this](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_custom_field_value) | resource |
@@ -33,7 +33,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_pagerduty_user_email"></a> [pagerduty\_user\_email](#input\_pagerduty\_user\_email) | Your PagerDuty Account E-Mail address. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Sample resources name | `string` | `"pdfbv2"` | no |
 


### PR DESCRIPTION
- テーブルの行セパレータのカラムの空白はテンプレートベースの変更なのでフラグでどうにもならない
- バージョンを上げない以外の回避策が思いつかない（できるの？）
- v0.21.0 のままにしておいて v0.23.0 以降で必要な変更が入ったら避けられないので今のうちに対応してしまう
- prek run -a で自動で処理させればそんなに問題ない